### PR TITLE
Added Artisan commands to clear cache and optimize in the CloudflareCacheServiceProvider's packageBooted method, excluding the commands in the local environment.

### DIFF
--- a/src/CloudflareCacheServiceProvider.php
+++ b/src/CloudflareCacheServiceProvider.php
@@ -57,7 +57,7 @@ class CloudflareCacheServiceProvider extends PackageServiceProvider
 
     public function packageBooted(): void
     {
-        if (!app()->environment('local')) {
+        if (! app()->environment('local')) {
             if (file_exists(config_path('glide.php'))) {
                 Artisan::call('glide:clear');
             }

--- a/src/CloudflareCacheServiceProvider.php
+++ b/src/CloudflareCacheServiceProvider.php
@@ -57,7 +57,7 @@ class CloudflareCacheServiceProvider extends PackageServiceProvider
 
     public function packageBooted()
     {
-        if (!app()->environment('local')) {
+        if (! app()->environment('local')) {
             Artisan::call('optimize:clear');
             Artisan::call('cloudflare-cache:clear');
         }

--- a/src/CloudflareCacheServiceProvider.php
+++ b/src/CloudflareCacheServiceProvider.php
@@ -55,11 +55,19 @@ class CloudflareCacheServiceProvider extends PackageServiceProvider
         $this->app->alias(CloudflareCacheInterface::class, 'cloudflare-cache');
     }
 
-    public function packageBooted()
+    public function packageBooted(): void
     {
-        if (! app()->environment('local')) {
-            Artisan::call('optimize:clear');
-            Artisan::call('cloudflare-cache:clear');
+        if (!app()->environment('local')) {
+            if (file_exists(config_path('glide.php'))) {
+                Artisan::call('glide:clear');
+            }
+
+            if (file_exists(config_path('cloudflare-cache.php'))) {
+                Artisan::call('optimize:clear');
+                Artisan::call('optimize');
+                sleep(5);
+                Artisan::call('cloudflare-cache:clear');
+            }
         }
     }
 }

--- a/src/CloudflareCacheServiceProvider.php
+++ b/src/CloudflareCacheServiceProvider.php
@@ -6,6 +6,7 @@ use Fuelviews\CloudflareCache\Commands\CloudflareCacheClearCommand;
 use Fuelviews\CloudflareCache\Services\CloudflareService;
 use Fuelviews\CloudflareCache\Services\CloudflareServiceInterface;
 use Illuminate\Http\Client\Factory;
+use Illuminate\Support\Facades\Artisan;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -52,5 +53,13 @@ class CloudflareCacheServiceProvider extends PackageServiceProvider
         });
 
         $this->app->alias(CloudflareCacheInterface::class, 'cloudflare-cache');
+    }
+
+    public function packageBooted()
+    {
+        if (!app()->environment('local')) {
+            Artisan::call('optimize:clear');
+            Artisan::call('cloudflare-cache:clear');
+        }
     }
 }

--- a/src/Commands/CloudflareCacheClearCommand.php
+++ b/src/Commands/CloudflareCacheClearCommand.php
@@ -5,6 +5,7 @@ namespace Fuelviews\CloudflareCache\Commands;
 use Fuelviews\CloudflareCache\Exceptions\CloudflareCacheRequestException;
 use Fuelviews\CloudflareCache\Facades\CloudflareCache;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
 use Symfony\Component\Console\Command\Command as CommandAlias;
 
 class CloudflareCacheClearCommand extends Command

--- a/src/Commands/CloudflareCacheClearCommand.php
+++ b/src/Commands/CloudflareCacheClearCommand.php
@@ -5,7 +5,6 @@ namespace Fuelviews\CloudflareCache\Commands;
 use Fuelviews\CloudflareCache\Exceptions\CloudflareCacheRequestException;
 use Fuelviews\CloudflareCache\Facades\CloudflareCache;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Artisan;
 use Symfony\Component\Console\Command\Command as CommandAlias;
 
 class CloudflareCacheClearCommand extends Command


### PR DESCRIPTION
Introduces the execution of Artisan commands to clear the cache and optimize the application in the `CloudflareCacheServiceProvider`'s `packageBooted` method. The key motivation behind this change is to ensure that our application maintains optimal performance by automatically clearing and optimizing caches whenever the package is booted, while deliberately excluding these commands in the local environment to avoid unnecessary disruptions during development.

By integrating these commands, we enhance the deployment process, ensuring that any stale cache is cleared and the application is optimized for production environments. This leads to improved reliability and performance of the Cloudflare caching service, ultimately benefiting users by providing a smoother experience.

In summary, this change streamlines cache management in production, while being mindful of the development workflow, thereby improving the overall robustness of the application.