### PR TITLE
Update GitHub Actions workflow to restrict permissions for pull requests and contents to read-only, enhancing security. Removed unnecessary configuration for GitHub token setup.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,8 +8,8 @@ on:
       - main
 
 permissions:
-  pull-requests: write
-  contents: write
+  pull-requests: read
+  contents: read
 
 jobs:
   test:
@@ -47,13 +47,6 @@ jobs:
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-      - name: Configure GitHub Token
-        env:
-          GH_TOKEN: ${{ secrets.GHA_PERSONAL_ACCESS_TOKEN }}
-        run: |
-          git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
-          git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "git@github.com:"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Enhances the security of our GitHub Actions workflow by updating the permissions for pull requests and repository contents to be read-only. By restricting `pull-requests` and `contents` permissions to `read`, we minimize the risk of unauthorized modifications, ensuring that only trusted code can be merged into the main branch.

Additionally, we have removed the unnecessary configuration for setting up a GitHub token. This simplifies the workflow and reduces potential security vulnerabilities associated with token management.

Overall, these changes improve the security posture of our CI/CD process, ensuring that our workflows adhere to best practices for access control while maintaining functionality.